### PR TITLE
Simplify case form fields and update typography to Arial

### DIFF
--- a/src/assets/styles/base.css
+++ b/src/assets/styles/base.css
@@ -20,7 +20,7 @@
 }
 
 body {
-    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
+    font-family: Arial, sans-serif;
     background-color: var(--sii-light-gray);
     color: #333;
     line-height: 1.6;

--- a/src/components/tabs/CaseTab.vue
+++ b/src/components/tabs/CaseTab.vue
@@ -6,7 +6,7 @@
           v-model="formData.rutContribuyente"
           label="RUT del contribuyente"
           type="text"
-          placeholder="12.345.678-9"
+          placeholder="10.222.222-3"
           @update:modelValue="updateField('rutContribuyente', $event)"
         />
 
@@ -14,52 +14,8 @@
           v-model="formData.nombreContribuyente"
           label="Nombre del contribuyente"
           type="text"
+          placeholder="Juan Pérez"
           @update:modelValue="updateField('nombreContribuyente', $event)"
-        />
-
-        <FormField
-          v-model="formData.fechaPresentacion"
-          label="Fecha presentación"
-          type="date"
-          @update:modelValue="updateField('fechaPresentacion', $event)"
-        />
-
-        <FormField
-          v-model="formData.fechaTramite"
-          label="Fecha tramite"
-          type="date"
-          @update:modelValue="updateField('fechaTramite', $event)"
-        />
-
-        <FormField
-          v-model="formData.abogado"
-          label="Abogado"
-          type="text"
-          @update:modelValue="updateField('abogado', $event)"
-        />
-
-        <FormField
-          v-model="formData.causaTER"
-          label="Causa TER"
-          type="select"
-          :options="causaTEROptions"
-          @update:modelValue="updateField('causaTER', $event)"
-        />
-
-        <FormField
-          v-model="formData.estado"
-          label="Estado"
-          type="select"
-          :options="estadoOptions"
-          @update:modelValue="updateField('estado', $event)"
-        />
-
-        <FormField
-          v-model="formData.giroEmitido"
-          label="Giro emitido"
-          type="select"
-          :options="giroEmitidoOptions"
-          @update:modelValue="updateField('giroEmitido', $event)"
         />
       </div>
 

--- a/src/components/tabs/CaseTab.vue
+++ b/src/components/tabs/CaseTab.vue
@@ -66,22 +66,7 @@ export default {
         { id: 'otros-documentos', label: 'Otros documentos', file: null },
         { id: 'archivo-aca', label: 'Archivo ACA', file: null }
       ],
-      // Form options
-      causaTEROptions: [
-        { value: '', label: 'Seleccionar...' },
-        { value: 'si', label: 'Sí' },
-        { value: 'no', label: 'No' }
-      ],
-      estadoOptions: [
-        { value: 'en-tramitacion', label: 'En tramitación' },
-        { value: 'resuelto', label: 'Resuelto' },
-        { value: 'archivado', label: 'Archivado' },
-        { value: 'suspendido', label: 'Suspendido' }
-      ],
-      giroEmitidoOptions: [
-        { value: 'no', label: 'No' },
-        { value: 'si', label: 'Sí' }
-      ]
+      // Form options (none needed for basic text fields)
     }
   },
   watch: {

--- a/src/components/tabs/CaseTab.vue
+++ b/src/components/tabs/CaseTab.vue
@@ -50,8 +50,7 @@ export default {
     return {
       formData: {
         rutContribuyente: '',
-        nombreContribuyente: '',
-        observaciones: ''
+        nombreContribuyente: ''
       },
       documents: [
         { id: 'acto-reclamado', label: 'Acto Reclamado', file: null },

--- a/src/components/tabs/CaseTab.vue
+++ b/src/components/tabs/CaseTab.vue
@@ -19,14 +19,6 @@
         />
       </div>
 
-      <FormField
-        v-model="formData.observaciones"
-        label="Observaciones"
-        type="textarea"
-        class="full-width"
-        @update:modelValue="updateField('observaciones', $event)"
-      />
-
       <!-- Document upload section -->
       <DocumentUpload
         :documents="documents"

--- a/src/components/tabs/CaseTab.vue
+++ b/src/components/tabs/CaseTab.vue
@@ -3,103 +3,63 @@
     <form class="case-form" @submit.prevent="handleSubmit">
       <div class="form-grid">
         <FormField
-          v-model="formData.tipoRecurso"
-          label="Tipo recurso"
-          type="select"
-          :options="tipoRecursoOptions"
-          @update:modelValue="updateField('tipoRecurso', $event)"
-        />
-
-        <FormField
-          v-model="formData.fechaInterposicion"
-          label="Fecha interposición"
-          type="date"
-          @update:modelValue="updateField('fechaInterposicion', $event)"
-        />
-
-        <FormField
-          v-model="formData.motivoReclamo"
-          label="Motivo reclamo"
-          type="select"
-          :options="motivoReclamoOptions"
-          @update:modelValue="updateField('motivoReclamo', $event)"
-        />
-
-        <FormField
-          v-model="formData.corte"
-          label="Corte"
-          type="select"
-          :options="corteOptions"
-          @update:modelValue="updateField('corte', $event)"
-        />
-
-        <FormField
-          v-model="formData.apoderados"
-          label="Apoderados contribuyente"
+          v-model="formData.rutContribuyente"
+          label="RUT del contribuyente"
           type="text"
-          @update:modelValue="updateField('apoderados', $event)"
+          placeholder="12.345.678-9"
+          @update:modelValue="updateField('rutContribuyente', $event)"
         />
 
         <FormField
-          v-model="formData.fechaSentencia"
-          label="Fecha sentencia"
+          v-model="formData.nombreContribuyente"
+          label="Nombre del contribuyente"
+          type="text"
+          @update:modelValue="updateField('nombreContribuyente', $event)"
+        />
+
+        <FormField
+          v-model="formData.fechaPresentacion"
+          label="Fecha presentación"
           type="date"
-          @update:modelValue="updateField('fechaSentencia', $event)"
+          @update:modelValue="updateField('fechaPresentacion', $event)"
         />
 
         <FormField
-          v-model="formData.decisionSentencia"
-          label="Decisión de sentencia"
+          v-model="formData.fechaTramite"
+          label="Fecha tramite"
+          type="date"
+          @update:modelValue="updateField('fechaTramite', $event)"
+        />
+
+        <FormField
+          v-model="formData.abogado"
+          label="Abogado"
+          type="text"
+          @update:modelValue="updateField('abogado', $event)"
+        />
+
+        <FormField
+          v-model="formData.causaTER"
+          label="Causa TER"
           type="select"
-          :options="decisionSentenciaOptions"
-          @update:modelValue="updateField('decisionSentencia', $event)"
+          :options="causaTEROptions"
+          @update:modelValue="updateField('causaTER', $event)"
         />
 
         <FormField
-          v-model="formData.recurrente"
-          label="Recurrente"
+          v-model="formData.estado"
+          label="Estado"
           type="select"
-          :options="recurrenteOptions"
-          @update:modelValue="updateField('recurrente', $event)"
+          :options="estadoOptions"
+          @update:modelValue="updateField('estado', $event)"
         />
 
         <FormField
-          v-model="formData.resultadoSentencia"
-          label="Resultado sentencia"
+          v-model="formData.giroEmitido"
+          label="Giro emitido"
           type="select"
-          :options="resultadoSentenciaOptions"
-          @update:modelValue="updateField('resultadoSentencia', $event)"
-        />
-
-        <FormField
-          v-model="formData.condenaCostas"
-          label="Condena en costas"
-          type="select"
-          :options="condenaCostasOptions"
-          @update:modelValue="updateField('condenaCostas', $event)"
-        />
-
-        <FormField
-          v-model="formData.montoCostas"
-          label="Monto costas"
-          type="number"
-          @update:modelValue="updateField('montoCostas', $event)"
-        />
-
-        <FormField
-          v-model="formData.eventoRelevante"
-          label="Evento relevante giro"
-          type="select"
-          :options="eventoRelevanteOptions"
-          @update:modelValue="updateField('eventoRelevante', $event)"
-        />
-
-        <FormField
-          v-model="formData.suspensionCobro"
-          label="Suspensión de cobro"
-          type="select"
-          :options="suspensionCobroOptions"
-          @update:modelValue="updateField('suspensionCobro', $event)"
+          :options="giroEmitidoOptions"
+          @update:modelValue="updateField('giroEmitido', $event)"
         />
       </div>
 

--- a/src/components/tabs/CaseTab.vue
+++ b/src/components/tabs/CaseTab.vue
@@ -53,9 +53,7 @@ export default {
         nombreContribuyente: ''
       },
       documents: [
-        { id: 'acto-reclamado', label: 'Acto Reclamado', file: null },
-        { id: 'otros-documentos', label: 'Otros documentos', file: null },
-        { id: 'archivo-aca', label: 'Archivo ACA', file: null }
+        { id: 'acto-reclamado', label: 'Acto Reclamado', file: null }
       ],
       // Form options (none needed for basic text fields)
     }

--- a/src/components/tabs/CaseTab.vue
+++ b/src/components/tabs/CaseTab.vue
@@ -59,12 +59,6 @@ export default {
       formData: {
         rutContribuyente: '',
         nombreContribuyente: '',
-        fechaPresentacion: '',
-        fechaTramite: '',
-        abogado: '',
-        causaTER: '',
-        estado: 'en-tramitacion',
-        giroEmitido: 'no',
         observaciones: ''
       },
       documents: [

--- a/src/components/tabs/CaseTab.vue
+++ b/src/components/tabs/CaseTab.vue
@@ -112,8 +112,9 @@ export default {
         observaciones: ''
       },
       documents: [
-        { id: 'sentencia', label: 'Sentencia', file: null },
-        { id: 'suspension', label: 'Suspensión de cobro', file: null }
+        { id: 'acto-reclamado', label: 'Acto Reclamado', file: null },
+        { id: 'otros-documentos', label: 'Otros documentos', file: null },
+        { id: 'archivo-aca', label: 'Archivo ACA', file: null }
       ],
       // Form options
       causaTEROptions: [

--- a/src/components/tabs/CaseTab.vue
+++ b/src/components/tabs/CaseTab.vue
@@ -101,19 +101,14 @@ export default {
   data() {
     return {
       formData: {
-        tipoRecurso: 'apelacion',
-        fechaInterposicion: '2023-07-15',
-        motivoReclamo: '',
-        corte: 'corte-suprema',
-        apoderados: '',
-        fechaSentencia: '2023-07-15',
-        decisionSentencia: 'ha-lugar-en-parte',
-        recurrente: 'ambos',
-        resultadoSentencia: 'favorable-en-parte',
-        condenaCostas: 'no',
-        montoCostas: 0,
-        eventoRelevante: 'no',
-        suspensionCobro: 'no',
+        rutContribuyente: '',
+        nombreContribuyente: '',
+        fechaPresentacion: '',
+        fechaTramite: '',
+        abogado: '',
+        causaTER: '',
+        estado: 'en-tramitacion',
+        giroEmitido: 'no',
         observaciones: ''
       },
       documents: [

--- a/src/components/tabs/CaseTab.vue
+++ b/src/components/tabs/CaseTab.vue
@@ -116,44 +116,18 @@ export default {
         { id: 'suspension', label: 'Suspensión de cobro', file: null }
       ],
       // Form options
-      tipoRecursoOptions: [
-        { value: 'apelacion', label: 'Apelación' },
-        { value: 'casacion', label: 'Casación' },
-        { value: 'queja', label: 'Queja' }
+      causaTEROptions: [
+        { value: '', label: 'Seleccionar...' },
+        { value: 'si', label: 'Sí' },
+        { value: 'no', label: 'No' }
       ],
-      motivoReclamoOptions: [
-        { value: '', label: 'No seleccionado' },
-        { value: 'devolucion', label: 'Devolución' },
-        { value: 'multa', label: 'Multa' }
+      estadoOptions: [
+        { value: 'en-tramitacion', label: 'En tramitación' },
+        { value: 'resuelto', label: 'Resuelto' },
+        { value: 'archivado', label: 'Archivado' },
+        { value: 'suspendido', label: 'Suspendido' }
       ],
-      corteOptions: [
-        { value: 'corte-suprema', label: 'Corte Suprema' },
-        { value: 'corte-apelaciones', label: 'Corte de Apelaciones' }
-      ],
-      decisionSentenciaOptions: [
-        { value: 'ha-lugar-en-parte', label: 'Ha lugar en parte' },
-        { value: 'rechaza', label: 'Rechaza' },
-        { value: 'acoge', label: 'Acoge' }
-      ],
-      recurrenteOptions: [
-        { value: 'ambos', label: 'Ambos' },
-        { value: 'contribuyente', label: 'Contribuyente' },
-        { value: 'sii', label: 'SII' }
-      ],
-      resultadoSentenciaOptions: [
-        { value: 'favorable-en-parte', label: 'Favorable en parte' },
-        { value: 'favorable', label: 'Favorable' },
-        { value: 'desfavorable', label: 'Desfavorable' }
-      ],
-      condenaCostasOptions: [
-        { value: 'no', label: 'No' },
-        { value: 'si', label: 'Sí' }
-      ],
-      eventoRelevanteOptions: [
-        { value: 'no', label: 'No' },
-        { value: 'si', label: 'Sí' }
-      ],
-      suspensionCobroOptions: [
+      giroEmitidoOptions: [
         { value: 'no', label: 'No' },
         { value: 'si', label: 'Sí' }
       ]

--- a/styles.css
+++ b/styles.css
@@ -6,7 +6,7 @@
 }
 
 body {
-    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
+    font-family: Arial, sans-serif;
     background-color: #f8fafc;
     color: #333;
     line-height: 1.6;


### PR DESCRIPTION
## Purpose

Based on user feedback, this PR simplifies the case form by replacing complex fields with basic contributor information fields as shown in the "acto reclamado" reference image. The changes also standardize typography to Arial only and streamline the document upload section to require only one document instead of three.

## Code changes

- **Typography**: Updated font-family from system fonts to Arial across all CSS files
- **Case form simplification**: 
  - Replaced 13 complex form fields with 2 basic fields (RUT and name of contributor)
  - Removed "Observaciones" textarea section
  - Simplified form data structure and removed all dropdown options
- **Document upload**: Reduced from 3 documents to 1 document ("Acto Reclamado")
- **Form validation**: Streamlined to match the simplified field structure

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 2`

🔗 [Edit in Builder.io](https://builder.io/app/projects/29251a8befd9425a8e9150310f46e176/stellar-forge)

👀 [Preview Link](https://29251a8befd9425a8e9150310f46e176-stellar-forge.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>29251a8befd9425a8e9150310f46e176</projectId>-->
<!--<branchName>stellar-forge</branchName>-->